### PR TITLE
Fixed compile errors

### DIFF
--- a/src/bmpread.c
+++ b/src/bmpread.c
@@ -6,6 +6,7 @@
 #if !defined( _WIN32 )
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 typedef int LONG;
 typedef unsigned long ULONG;

--- a/src/cmdlib.c
+++ b/src/cmdlib.c
@@ -1,6 +1,7 @@
 #include "cmdlib.h"
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #ifdef WIN32
 #include <direct.h>
@@ -233,7 +234,7 @@ void Q_getwd (char *out)
    _getcwd (out, 256);
    strcat (out, "\\");
 #else
-   getwd (out);
+   getcwd (out, 256);
 #endif
 }
 

--- a/src/studiomdl.c
+++ b/src/studiomdl.c
@@ -31,6 +31,15 @@ void clip_rotations( vec3_t rot );
 #define strcpyn( a, b ) strncpy( a, b, sizeof( a ) )
 
 int k_memtotal;
+int numbones = 0;
+int numrenamedbones = 0;
+int numhitgroups = 0;
+int numhitboxes = 0;
+s_bonecontroller_t bonecontroller[MAXSTUDIOSRCBONES];
+int numbonecontrollers = 0;
+s_attachment_t attachment[MAXSTUDIOSRCBONES];
+int numattachments = 0;
+
 void *kalloc( int num, int size )
 {
 	// printf( "calloc( %d, %d )\n", num, size );

--- a/src/studiomdl.h
+++ b/src/studiomdl.h
@@ -75,7 +75,7 @@ typedef struct
 } s_bonefixup_t;
 EXTERN	s_bonefixup_t bonefixup[MAXSTUDIOSRCBONES];
 
-int numbones;
+extern int numbones;
 typedef struct
 {
 	char			name[32];	// bone name for symbolic links
@@ -92,7 +92,7 @@ typedef struct
 } s_bonetable_t;
 EXTERN	s_bonetable_t bonetable[MAXSTUDIOSRCBONES];
 
-int numrenamedbones;
+extern int numrenamedbones;
 typedef struct
 {
 	char			from[32];
@@ -100,7 +100,7 @@ typedef struct
 } s_renamebone_t;
 EXTERN s_renamebone_t renamedbone[MAXSTUDIOSRCBONES];
 
-int numhitboxes;
+extern int numhitboxes;
 typedef struct
 {
 	char			name[32];	// bone name
@@ -111,7 +111,7 @@ typedef struct
 } s_bbox_t;
 EXTERN s_bbox_t hitbox[MAXSTUDIOSRCBONES];
 
-int numhitgroups;
+extern int numhitgroups;
 typedef struct
 {
 	int				models;
@@ -131,8 +131,8 @@ typedef struct
 	float	end;
 } s_bonecontroller_t;
 
-s_bonecontroller_t bonecontroller[MAXSTUDIOSRCBONES];
-int numbonecontrollers;
+extern s_bonecontroller_t bonecontroller[MAXSTUDIOSRCBONES];
+extern int numbonecontrollers;
 
 typedef struct
 {
@@ -144,8 +144,8 @@ typedef struct
 	vec3_t	org;
 } s_attachment_t;
 
-s_attachment_t attachment[MAXSTUDIOSRCBONES];
-int numattachments;
+extern s_attachment_t attachment[MAXSTUDIOSRCBONES];
+extern int numattachments;
 
 typedef struct
 {


### PR DESCRIPTION
Hello

I tried to compile this on Arch Linux, but I've got compilation errors. To be more precise: the object files were generated just fine, these errors occurred at the linker phase. 
I did some changes, and now it works.

The errors were caused by:

- Use of memmove without including string.h
- Multiple definitions of variables (fixed by declaring them with extern on the header file and initializing them on studiomdl.c...I am not a C magician, so tell me if this isn't the right way to do it)
- Use of deprecated and unsafe getwc function, which I replaced with getcwc from unistd.h

In case this isn't merged, I include the patch here anyways to download in case anyone else is having the same issue.

Cheers,

Elim Garak (just a tailor...)

Patch file (I had to upload it as a .txt instead of .patch because of a dumb GitHub bug, sorry):
[0001-Fixed-compile-errors-caused-by-Use-of-deprecated-and.txt](https://github.com/fnky/studiomdl/files/14234894/0001-Fixed-compile-errors-caused-by-Use-of-deprecated-and.txt)